### PR TITLE
feat: handling for "`.`" -delimited column names

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -50,7 +50,13 @@ func extractNormalizedInsertQueryAndColumns(query string) (normalizedQuery strin
 		for i := range columns {
 			// refers to https://clickhouse.com/docs/en/sql-reference/syntax#identifiers
 			// we can use identifiers with double quotes or backticks, for example: "id", `id`, but not both, like `"id"`.
-			columns[i] = strings.Trim(strings.Trim(strings.TrimSpace(columns[i]), "\""), "`")
+			col := columns[i]
+			col = strings.TrimSpace(columns[i]) // trim leading/trailin whitespace
+			col = strings.Trim(col, "\"")       // trim leading/trailing double quote
+			col = strings.Trim(col, "`")        // trim leading/trialing backtick
+			// for columns like events.attributes that are otherwise represented like this: events`.`attributes
+			col = strings.ReplaceAll(col, "`.`", ".") // replace internal backtick delimited periods w/ a plain period
+			columns[i] = col
 		}
 	}
 


### PR DESCRIPTION
`extractNormalizedInsertQueryAndColumns` cleans column names but it misses a case where the column name is `.`. This is an issue for clickhouse nested columns. 

For example, go-gorm will produce sql with column names liek `events`.`attributes` and `links`.`span_id`. While the leading and trailing backticks are removed, the inner backticks remain which causes a `block cannot be sorted - missing columns in requested order` error.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
